### PR TITLE
Fix race condition in Jest test

### DIFF
--- a/util/__tests__/dataStructure.test.ts
+++ b/util/__tests__/dataStructure.test.ts
@@ -2,13 +2,14 @@ import { expect, test } from '@jest/globals';
 import { reduceAnimalsWithFoods } from '../dataStructures';
 
 test('reduce animal favorite foods', () => {
+  const animalBirthDate = new Date();
   const animalWithFood = [
     {
       animalId: 1,
       animalFirstName: 'Lucia',
       animalType: 'Lion',
       animalAccessory: 'Car',
-      animalBirthDate: new Date(),
+      animalBirthDate: animalBirthDate,
       animalFoodId: 3,
       animalFoodName: 'Rice',
       animalFoodType: 'Grain',
@@ -18,7 +19,7 @@ test('reduce animal favorite foods', () => {
       animalFirstName: 'Lucia',
       animalType: 'Lion',
       animalAccessory: 'Car',
-      animalBirthDate: new Date(),
+      animalBirthDate: animalBirthDate,
       animalFoodId: 4,
       animalFoodName: 'Mango',
       animalFoodType: 'Fruit',
@@ -30,7 +31,7 @@ test('reduce animal favorite foods', () => {
     firstName: 'Lucia',
     type: 'Lion',
     accessory: 'Car',
-    birthDate: new Date(),
+    birthDate: animalBirthDate,
     animalFoods: [
       { id: 3, name: 'Rice', type: 'Grain' },
       { id: 4, name: 'Mango', type: 'Fruit' },


### PR DESCRIPTION
The dates are being created separately, although it's supposed to be the same date.

This means that [the dates are sometimes not matching (race condition)](https://github.com/upleveled/next-js-example-fall-2024-atvie/actions/runs/11350748792/job/31569829799?pr=5):

```
pnpm jest
  pnpm jest
  shell: /usr/bin/bash -e {0}
  env:
    PGHOST: localhost
    PGDATABASE: next_js_example_fall_2024
    PGUSERNAME: next_js_example_fall_2024
    PGPASSWORD: next_js_example_fall_2024
    PNPM_HOME: /home/runner/setup-pnpm/node_modules/.bin
PASS util/__tests__/math.test.ts
PASS util/__tests__/date.test.ts
FAIL util/__tests__/dataStructure.test.ts
  ● reduce animal favorite foods

    expect(received).toStrictEqual(expected) // deep equality

    - Expected  - 1
    + Received  + 1

    @@ -10,10 +10,10 @@
            "id": 4,
            "name": "Mango",
            "type": "Fruit",
          },
        ],
    -   "birthDate": 2024-10-15T16:55:52.192Z,
    +   "birthDate": 2024-10-15T16:55:52.191Z,
        "firstName": "Lucia",
        "id": 1,
        "type": "Lion",
      }

      38 |   };
      39 |
    > 40 |   expect(reduceAnimalsWithFoods(animalWithFood)).toStrictEqual(
         |                                                  ^
      41 |     reducedAnimalWithFoods,
      42 |   );
      43 | });

      at Object.toStrictEqual (util/__tests__/dataStructure.test.ts:40:50)

Test Suites: 1 failed, 2 passed, 3 total
Tests:       1 failed, 7 passed, 8 total
Snapshots:   0 total
Time:        1.183 s
Ran all test suites.
Error: Process completed with exit code 1.
```