### PR TITLE
Add better UI for different errors on note page

### DIFF
--- a/app/notes/[noteId]/page.tsx
+++ b/app/notes/[noteId]/page.tsx
@@ -16,9 +16,7 @@ export default async function NotePage({ params }: Props) {
   const sessionTokenCookie = await getCookie('sessionToken');
 
   // 2. Check if the note exists
-  const noteExists = await selectNoteExists(noteId);
-
-  if (!noteExists) {
+  if (!(await selectNoteExists(noteId))) {
     return (
       <div>
         <h1>Error loading note {noteId}</h1>

--- a/app/notes/[noteId]/page.tsx
+++ b/app/notes/[noteId]/page.tsx
@@ -28,8 +28,7 @@ export default async function NotePage({ params }: Props) {
 
   // 3. Query the notes with the session token and noteId
   const note =
-    sessionTokenCookie &&
-    (await getNote(sessionTokenCookie, Number((await params).noteId)));
+    sessionTokenCookie && (await getNote(sessionTokenCookie, noteId));
 
   // 4. If there is no note for the current user, show restricted access message
   if (!note) {

--- a/database/notes.ts
+++ b/database/notes.ts
@@ -35,6 +35,22 @@ export const getNote = cache(async (sessionToken: string, noteId: number) => {
   return note;
 });
 
+export async function selectNoteExists(noteId: Note['id']) {
+  const [record] = await sql<{ exists: boolean }[]>`
+    SELECT
+      EXISTS (
+        SELECT
+          TRUE
+        FROM
+          notes
+        WHERE
+          id = ${noteId}
+      )
+  `;
+
+  return Boolean(record?.exists);
+}
+
 export const createNote = cache(
   async (
     sessionToken: Session['token'],


### PR DESCRIPTION
Ensure that the UI displayed to users reflects the exact condition of what is happening

When a user queries for a note that doesn't exist, we want to display a UI that shows this to the user instead of showing `Access Denied` in this case.